### PR TITLE
404 sig redirect

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react-router-dom": "^6.3.0",
     "react-router-hash-link": "^2.4.3",
     "react-scripts": "5.0.1",
+    "react-use-window-scroll": "^1.1.1",
     "styled-components": "^5.3.5",
     "typescript": "^4.7.4",
     "web-vitals": "^2.1.4"

--- a/public/404.html
+++ b/public/404.html
@@ -598,7 +598,7 @@
             </div>
             <ul class="nav nav-pills main_nav">
               <li><a href="https://acm.illinois.edu/">About</a></li>
-              <li><a href="https://acm.illinois.edu/#/#sighighlight">SIGs</a></li>
+              <li><a href="https://acm.illinois.edu/?notfound=true">SIGs</a></li>
             </ul>
     
           </div>

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -2,7 +2,8 @@ import styled from 'styled-components';
 import Text from '../Text/Text';
 import { Link } from 'react-router-dom';
 import { HashLink } from 'react-router-hash-link';
-import { useRef } from 'react';
+import { useEffect, useRef } from 'react';
+
 
 const NavHeader = styled.header`
   height: 105px;
@@ -182,6 +183,7 @@ const SiteTitle = styled((props: any) => <Text {...props} />)`
 `;
 
 function Navbar({ ...rest }: any) {
+  
   const checkbox = useRef<HTMLInputElement | null>(null);
   const scrollLock = useRef(false);
 
@@ -189,6 +191,7 @@ function Navbar({ ...rest }: any) {
     if (checkbox && checkbox.current != null) {
       checkbox.current.checked = false;
     }
+
     removeLockIfApplied();
   };
 
@@ -207,6 +210,20 @@ function Navbar({ ...rest }: any) {
       scrollLock.current = false;
     }
   };
+
+  
+
+  useEffect(() => {
+    const url = window.location.href.split("=");
+    console.log(url)
+    const sigButton = document.querySelector('#sigbutton') as HTMLElement;
+    if (url.length > 1 && url[1] === 'true') {
+      if (sigButton) {
+        sigButton.click();
+      }
+    }
+  });
+
 
   return (
     <NavContainer {...rest}>
@@ -243,6 +260,7 @@ function Navbar({ ...rest }: any) {
                 as={HashLink}
                 to="/#sighighlight"
                 className="navLink"
+                id="sigbutton"
                 onClick={uncheck}
               >
                 SIGs

--- a/yarn.lock
+++ b/yarn.lock
@@ -13377,6 +13377,13 @@ react-snap@^1.23.0:
     serve-static "1.13.2"
     sourcemapped-stacktrace-node "2.1.8"
 
+react-use-window-scroll@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/react-use-window-scroll/-/react-use-window-scroll-1.1.1.tgz#7b23e21a4fd0f34756a10e8d42ecb79021d7d335"
+  integrity sha512-MChXBqf3Wf85ozkN1TCdUixHAHH2URXCM//kGO6GJlO+ojXUze6BhoixiG4swoaRbdz6aRe674eQXv+TnUnM5w==
+  dependencies:
+    smoothscroll-polyfill "^0.4.4"
+
 react@^18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
@@ -14192,6 +14199,11 @@ slash@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-4.0.0.tgz#2422372176c4c6c5addb5e2ada885af984b396a7"
   integrity sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==
+
+smoothscroll-polyfill@^0.4.4:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/smoothscroll-polyfill/-/smoothscroll-polyfill-0.4.4.tgz#3a259131dc6930e6ca80003e1cb03b603b69abf8"
+  integrity sha512-TK5ZA9U5RqCwMpfoMq/l1mrH0JAR7y7KRvOBx0n2869aLxch+gT9GhN3yUfjiw+d/DiF1mKo14+hd62JyMmoBg==
 
 snapdragon-node@^2.0.1:
   version "2.1.1"


### PR DESCRIPTION
I have added a query parameter to the 404-page sign-up button. When the user clicks the button and gets redirected to the home page, I use the useEffect function to check the query parameter. If it satisfies the condition, I trigger a click event. This method works, while the previous method of using 'https://acm.illinois.edu/#/#sighighlight' did not work.
There may be two reasons:
1. I believe this is because we are using the and the server is unable to read the information after the '#' symbol.
2. Another possible reason is that when we redirect to the '#sighighlight' section, the page does not fully load.

In the future, we can explore alternative methods to achieve the same result without using URL query parameters.