### PR TITLE
Updated alignment for calendar page

### DIFF
--- a/src/app/(main)/calendar/page.tsx
+++ b/src/app/(main)/calendar/page.tsx
@@ -68,7 +68,7 @@ const Calendar = () => {
   };
 
   // Label text showing on the filter box
-  const filterLabel = window.innerWidth >= 460 ? "Filter by host" : "Filter";
+  const filterLabel = typeof window !== "undefined" && window.innerWidth >= 460 ? "Filter by host" : "Filter";
 
   return (
     <Suspense>

--- a/src/app/(main)/calendar/page.tsx
+++ b/src/app/(main)/calendar/page.tsx
@@ -70,37 +70,41 @@ const Calendar = () => {
     <Suspense>
       <section className="container">
         <h1 className='mt-0 pt-0 mb-4'>Our Events</h1>
-        <div className="flex">
-          <CalendarControls currDisplayDate={displayDate} updateDisplayDate={setDisplayDate} currView={view} updateCurrView={setView} />
-          <div className="hidden xl:flex">
-            <select
-              value={hostFilter}
-              onChange={(e) => {
-                setHostFilter(e.target.value);
-                const baseURL = window ? window.location.origin : 'https://acm.illinois.edu';
-                if (e.target.value === "") {
-                  window.history.replaceState(null, '', baseURL + `/calendar`);
-                } else {
-                  window.history.replaceState(null, '', baseURL + `/calendar?host=${e.target.value.replaceAll(" ", "+")}`);
-
-                }
-              }}
-              className="border-2 border-gray-300 rounded-md mr-2 px-2" // Styling for the dropdown
-            >
-              <option value="">Filter by host</option>
-              {validOrganizations.map((org) => (
-                <option key={org} value={org}>{org}</option>
-              ))}
-            </select>
+        <div className="grid lg:grid-cols-3 xl:grid-cols-8 w-full gap-4">
+          <div className='flex lg:col-span-2 xl:col-span-5'>
+            <CalendarControls currDisplayDate={displayDate} updateDisplayDate={setDisplayDate} currView={view} updateCurrView={setView} />
           </div>
-          <div className="hidden lg:flex">
-            <input
-              type="text"
-              placeholder="Search events"
-              value={filter}
-              onChange={handleFilterChange}
-              className="ml-4 px-2 border-2 border-gray-300 focus:border-blue-500 rounded-md" // Updated styling
-            />
+          <div className='flex lg:col-span-1 xl:col-span-3 w-full gap-4 justify-end'>
+            <div className="hidden xl:flex xl:w-2/5">
+              <select
+                value={hostFilter}
+                onChange={(e) => {
+                  setHostFilter(e.target.value);
+                  const baseURL = window ? window.location.origin : 'https://acm.illinois.edu';
+                  if (e.target.value === "") {
+                    window.history.replaceState(null, '', baseURL + `/calendar`);
+                  } else {
+                    window.history.replaceState(null, '', baseURL + `/calendar?host=${e.target.value.replaceAll(" ", "+")}`);
+
+                  }
+                }}
+                className="px-2 border-2 border-gray-300 rounded-md w-full" // Styling for the dropdown
+              >
+                <option value="">Filter by host</option>
+                {validOrganizations.map((org) => (
+                  <option key={org} value={org}>{org}</option>
+                ))}
+              </select>
+            </div>
+            <div className="hidden lg:flex xl:w-3/5">
+              <input
+                type="text"
+                placeholder="Search events"
+                value={filter}
+                onChange={handleFilterChange}
+                className="px-2 border-2 border-gray-300 focus:border-blue-500 rounded-md w-full" // Updated styling
+              />
+            </div>
           </div>
         </div>
         <div className='grid justify-between pb-10 gap-4 grid-cols-8'>

--- a/src/app/(main)/calendar/page.tsx
+++ b/src/app/(main)/calendar/page.tsx
@@ -70,7 +70,7 @@ const Calendar = () => {
     <Suspense>
       <section className="container">
         <h1 className='mt-0 pt-0 mb-4'>Our Events</h1>
-        <div className="grid lg:grid-cols-3 xl:grid-cols-8 w-full gap-6">
+        <div className="grid lg:grid-cols-3 xl:grid-cols-8 w-full gapx-6">
           <div className='flex lg:col-span-2 xl:col-span-5'>
             <CalendarControls currDisplayDate={displayDate} updateDisplayDate={setDisplayDate} currView={view} updateCurrView={setView} />
           </div>

--- a/src/app/(main)/calendar/page.tsx
+++ b/src/app/(main)/calendar/page.tsx
@@ -70,12 +70,12 @@ const Calendar = () => {
     <Suspense>
       <section className="container">
         <h1 className='mt-0 pt-0 mb-4'>Our Events</h1>
-        <div className="grid md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-8 w-full gap-x-6">
-          <div className='flex md:col-span-1 lg:col-span-1 xl:col-span-5'>
+        <div className="grid grid-cols-2 xl:grid-cols-8 w-full gap-x-6">
+          <div className='flex col-span-1 xl:col-span-5'>
             <CalendarControls currDisplayDate={displayDate} updateDisplayDate={setDisplayDate} currView={view} updateCurrView={setView} />
           </div>
-          <div className='flex h-[2.5rem] mt-auto md:col-span-1 lg:col-span-1 lg:mt-0 xl:col-span-3 w-full gap-x-4 justify-end'>
-            <div className="hidden md:flex md:w-1/2 lg:w-2/5">
+          <div className='flex h-[2.5rem] mt-auto col-span-1 lg:mt-0 xl:col-span-3 w-full gap-x-4 justify-end'>
+            <div className="md:flex md:w-1/2 lg:w-2/5">
               <select
                 value={hostFilter}
                 onChange={(e) => {
@@ -88,7 +88,7 @@ const Calendar = () => {
 
                   }
                 }}
-                className="px-2 border-2 border-gray-300 rounded-md w-full" // Styling for the dropdown
+                className="px-2 border-2 border-gray-300 rounded-md w-full h-full" // Styling for the dropdown
               >
                 <option value="">Filter by host</option>
                 {validOrganizations.map((org) => (
@@ -102,7 +102,7 @@ const Calendar = () => {
                 placeholder="Search events"
                 value={filter}
                 onChange={handleFilterChange}
-                className="px-2 border-2 border-gray-300 focus:border-blue-500 rounded-md w-full" // Updated styling
+                className="px-2 border-2 border-gray-300 focus:border-blue-500 rounded-md w-full h-full" // Updated styling
               />
             </div>
           </div>

--- a/src/app/(main)/calendar/page.tsx
+++ b/src/app/(main)/calendar/page.tsx
@@ -70,11 +70,11 @@ const Calendar = () => {
     <Suspense>
       <section className="container">
         <h1 className='mt-0 pt-0 mb-4'>Our Events</h1>
-        <div className="grid lg:grid-cols-3 xl:grid-cols-8 w-full gapx-6">
+        <div className="grid lg:grid-cols-3 xl:grid-cols-8 w-full gap-x-6">
           <div className='flex lg:col-span-2 xl:col-span-5'>
             <CalendarControls currDisplayDate={displayDate} updateDisplayDate={setDisplayDate} currView={view} updateCurrView={setView} />
           </div>
-          <div className='flex lg:col-span-1 xl:col-span-3 w-full gap-4 justify-end'>
+          <div className='flex lg:col-span-1 xl:col-span-3 w-full gap-x-4 justify-end'>
             <div className="hidden xl:flex xl:w-2/5">
               <select
                 value={hostFilter}
@@ -107,7 +107,7 @@ const Calendar = () => {
             </div>
           </div>
         </div>
-        <div className='grid justify-between pb-10 gapx-6 grid-cols-8'>
+        <div className='grid justify-between pb-10 gap-x-6 grid-cols-8'>
           <div className="flex xl:order-last col-span-8 xl:col-span-3">
             <EventDetail
               title={eventDetail.title}

--- a/src/app/(main)/calendar/page.tsx
+++ b/src/app/(main)/calendar/page.tsx
@@ -70,12 +70,12 @@ const Calendar = () => {
     <Suspense>
       <section className="container">
         <h1 className='mt-0 pt-0 mb-4'>Our Events</h1>
-        <div className="grid lg:grid-cols-3 xl:grid-cols-8 w-full gap-x-6">
-          <div className='flex lg:col-span-2 xl:col-span-5'>
+        <div className="grid lg:grid-cols-2 xl:grid-cols-8 w-full gap-x-6">
+          <div className='flex lg:col-span-1 xl:col-span-5'>
             <CalendarControls currDisplayDate={displayDate} updateDisplayDate={setDisplayDate} currView={view} updateCurrView={setView} />
           </div>
           <div className='flex lg:col-span-1 xl:col-span-3 w-full gap-x-4 justify-end'>
-            <div className="hidden xl:flex xl:w-2/5">
+            <div className="hidden lg:flex lg:w-2/5">
               <select
                 value={hostFilter}
                 onChange={(e) => {
@@ -96,7 +96,7 @@ const Calendar = () => {
                 ))}
               </select>
             </div>
-            <div className="hidden lg:flex xl:w-3/5">
+            <div className="hidden lg:flex lg:w-3/5">
               <input
                 type="text"
                 placeholder="Search events"

--- a/src/app/(main)/calendar/page.tsx
+++ b/src/app/(main)/calendar/page.tsx
@@ -66,16 +66,20 @@ const Calendar = () => {
   const handleFilterChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setFilter(e.target.value);
   };
+
+  // Label text showing on the filter box
+  const filterLabel = window.innerWidth >= 460 ? "Filter by host" : "Filter";
+
   return (
     <Suspense>
       <section className="container">
         <h1 className='mt-0 pt-0 mb-4'>Our Events</h1>
-        <div className="grid grid-cols-2 xl:grid-cols-8 w-full gap-x-6">
-          <div className='flex col-span-1 xl:col-span-5'>
+        <div className="flex sm:grid sm:grid-cols-2 xl:grid-cols-8 w-full gap-x-6">
+          <div className='flex sm:col-span-1 xl:col-span-5'>
             <CalendarControls currDisplayDate={displayDate} updateDisplayDate={setDisplayDate} currView={view} updateCurrView={setView} />
           </div>
-          <div className='flex h-[2.5rem] mt-auto col-span-1 lg:mt-0 xl:col-span-3 w-full gap-x-4 justify-end'>
-            <div className="md:flex md:w-1/2 lg:w-2/5">
+          <div className='flex h-[2.5rem] mt-auto sm:col-span-1 lg:mt-0 xl:col-span-3 w-full gap-x-4 justify-end'>
+            <div className="flex md:w-1/2 lg:w-2/5">
               <select
                 value={hostFilter}
                 onChange={(e) => {
@@ -90,7 +94,7 @@ const Calendar = () => {
                 }}
                 className="px-2 border-2 border-gray-300 rounded-md w-full h-full" // Styling for the dropdown
               >
-                <option value="">Filter by host</option>
+                <option value="">{filterLabel}</option>
                 {validOrganizations.map((org) => (
                   <option key={org} value={org}>{org}</option>
                 ))}

--- a/src/app/(main)/calendar/page.tsx
+++ b/src/app/(main)/calendar/page.tsx
@@ -70,7 +70,7 @@ const Calendar = () => {
     <Suspense>
       <section className="container">
         <h1 className='mt-0 pt-0 mb-4'>Our Events</h1>
-        <div className="grid lg:grid-cols-3 xl:grid-cols-8 w-full gap-4">
+        <div className="grid lg:grid-cols-3 xl:grid-cols-8 w-full gap-6">
           <div className='flex lg:col-span-2 xl:col-span-5'>
             <CalendarControls currDisplayDate={displayDate} updateDisplayDate={setDisplayDate} currView={view} updateCurrView={setView} />
           </div>
@@ -107,7 +107,7 @@ const Calendar = () => {
             </div>
           </div>
         </div>
-        <div className='grid justify-between pb-10 gap-4 grid-cols-8'>
+        <div className='grid justify-between pb-10 gap-6 grid-cols-8'>
           <div className="flex xl:order-last col-span-8 xl:col-span-3">
             <EventDetail
               title={eventDetail.title}

--- a/src/app/(main)/calendar/page.tsx
+++ b/src/app/(main)/calendar/page.tsx
@@ -74,7 +74,7 @@ const Calendar = () => {
           <div className='flex md:col-span-1 lg:col-span-1 xl:col-span-5'>
             <CalendarControls currDisplayDate={displayDate} updateDisplayDate={setDisplayDate} currView={view} updateCurrView={setView} />
           </div>
-          <div className='flex md:col-span-1 lg:col-span-1 xl:col-span-3 w-full gap-x-4 justify-end'>
+          <div className='flex h-[2.5rem] mt-auto md:col-span-1 lg:col-span-1 lg:mt-0 xl:col-span-3 w-full gap-x-4 justify-end'>
             <div className="hidden md:flex md:w-1/2 lg:w-2/5">
               <select
                 value={hostFilter}

--- a/src/app/(main)/calendar/page.tsx
+++ b/src/app/(main)/calendar/page.tsx
@@ -107,7 +107,7 @@ const Calendar = () => {
             </div>
           </div>
         </div>
-        <div className='grid justify-between pb-10 gap-6 grid-cols-8'>
+        <div className='grid justify-between pb-10 gapx-6 grid-cols-8'>
           <div className="flex xl:order-last col-span-8 xl:col-span-3">
             <EventDetail
               title={eventDetail.title}

--- a/src/app/(main)/calendar/page.tsx
+++ b/src/app/(main)/calendar/page.tsx
@@ -70,12 +70,12 @@ const Calendar = () => {
     <Suspense>
       <section className="container">
         <h1 className='mt-0 pt-0 mb-4'>Our Events</h1>
-        <div className="grid lg:grid-cols-2 xl:grid-cols-8 w-full gap-x-6">
-          <div className='flex lg:col-span-1 xl:col-span-5'>
+        <div className="grid md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-8 w-full gap-x-6">
+          <div className='flex md:col-span-1 lg:col-span-1 xl:col-span-5'>
             <CalendarControls currDisplayDate={displayDate} updateDisplayDate={setDisplayDate} currView={view} updateCurrView={setView} />
           </div>
-          <div className='flex lg:col-span-1 xl:col-span-3 w-full gap-x-4 justify-end'>
-            <div className="hidden lg:flex lg:w-2/5">
+          <div className='flex md:col-span-1 lg:col-span-1 xl:col-span-3 w-full gap-x-4 justify-end'>
+            <div className="hidden md:flex md:w-1/2 lg:w-2/5">
               <select
                 value={hostFilter}
                 onChange={(e) => {
@@ -96,7 +96,7 @@ const Calendar = () => {
                 ))}
               </select>
             </div>
-            <div className="hidden lg:flex lg:w-3/5">
+            <div className="hidden md:flex md:w-1/2 lg:w-3/5">
               <input
                 type="text"
                 placeholder="Search events"

--- a/src/app/(main)/calendar/page.tsx
+++ b/src/app/(main)/calendar/page.tsx
@@ -74,11 +74,11 @@ const Calendar = () => {
     <Suspense>
       <section className="container">
         <h1 className='mt-0 pt-0 mb-4'>Our Events</h1>
-        <div className="flex sm:grid sm:grid-cols-2 xl:grid-cols-8 w-full gap-x-6">
-          <div className='flex sm:col-span-1 xl:col-span-5'>
+        <div className="flex sm:grid sm:grid-cols-3 md:grid-cols-2 xl:grid-cols-8 w-full gap-x-6">
+          <div className='flex sm:col-span-2 md:col-span-1 xl:col-span-5'>
             <CalendarControls currDisplayDate={displayDate} updateDisplayDate={setDisplayDate} currView={view} updateCurrView={setView} />
           </div>
-          <div className='flex h-[2.5rem] mt-auto sm:col-span-1 lg:mt-0 xl:col-span-3 w-full gap-x-4 justify-end'>
+          <div className='flex h-[2.5rem] mt-auto sm:col-span-1 md:col-span-1 lg:mt-0 xl:col-span-3 w-full gap-x-4 justify-end'>
             <div className="flex md:w-1/2 lg:w-2/5">
               <select
                 value={hostFilter}

--- a/src/components/CalendarControls/index.tsx
+++ b/src/components/CalendarControls/index.tsx
@@ -47,10 +47,10 @@ export default function CalendarControls({currDisplayDate, updateDisplayDate, cu
     return (
     <>
     <div className="grid lg:grid-cols-12 grid-cols-8 w-full">
-      <div className="flex col-span-3 md:col-span-4 lg:col-span-5 items-center">
+      <div className="flex col-span-3 md:col-span-4 lg:col-span-6 items-center">
         <div className="text-xl font-bold">{currView == Views.DAY ? getCurrentDate(currDisplayDate) : extractMonthAndYear(currDisplayDate)}</div>
       </div>
-        <div className="flex items-center ml-4 gap-x-4 col-span-5 md:col-span-4 lg:col-span-6">
+        <div className="flex items-center justify-end ml-4 gap-x-4 col-span-5 md:col-span-4 lg:col-span-6">
           <Button onPress={()=> {resetDate()}} variant="bordered" className="border-surface-000 border-1 bg-primary text-white hover:cursor-pointer hidden md:block">Today</Button>
           <ButtonGroup>
               <Button isIconOnly onPress={() => {changeDate(-1, currView)}} variant="bordered" className="border-surface-000 border-1 bg-primary text-white hover:cursor-pointer "><FaArrowLeft /></Button>

--- a/src/components/CalendarControls/index.tsx
+++ b/src/components/CalendarControls/index.tsx
@@ -46,11 +46,11 @@ export default function CalendarControls({currDisplayDate, updateDisplayDate, cu
     }
     return (
     <>
-    <div className="gap-y-4 lg:grid lg:grid-cols-12 lg:grid-cols-8 lg:w-full">
-      <div className="flex items-center pb-1 lg:pb-0 lg:col-span-3 lg:col-span-6">
+    <div className="gap-y-4 lg:flex lg:grid-cols-2 lg:w-full lg:justify-between">
+      <div className="flex items-center pb-1 lg:pb-0 lg:col-span-1">
         <div className="text-xl font-bold">{currView == Views.DAY ? getCurrentDate(currDisplayDate) : extractMonthAndYear(currDisplayDate)}</div>
       </div>
-        <div className="flex items-center gap-x-4 justify-end lg:col-span-5 lg:ml-4 lg:col-span-6">
+        <div className="flex items-center gap-x-4 lg:ml-4 lg:col-span-1">
           <Button onPress={()=> {resetDate()}} variant="bordered" className="border-surface-000 border-1 bg-primary text-white hover:cursor-pointer hidden md:block">Today</Button>
           <ButtonGroup>
               <Button isIconOnly onPress={() => {changeDate(-1, currView)}} variant="bordered" className="border-surface-000 border-1 bg-primary text-white hover:cursor-pointer "><FaArrowLeft /></Button>

--- a/src/components/CalendarControls/index.tsx
+++ b/src/components/CalendarControls/index.tsx
@@ -46,11 +46,11 @@ export default function CalendarControls({currDisplayDate, updateDisplayDate, cu
     }
     return (
     <>
-    <div className="grid lg:grid-cols-12 grid-cols-8 w-full">
-      <div className="flex col-span-3 md:col-span-4 lg:col-span-6 items-center">
+    <div className="gap-y-4 lg:grid lg:grid-cols-12 lg:grid-cols-8 lg:w-full">
+      <div className="flex items-center pb-1 lg:pb-0 lg:col-span-3 lg:col-span-6">
         <div className="text-xl font-bold">{currView == Views.DAY ? getCurrentDate(currDisplayDate) : extractMonthAndYear(currDisplayDate)}</div>
       </div>
-        <div className="flex items-center justify-end ml-4 gap-x-4 col-span-5 md:col-span-4 lg:col-span-6">
+        <div className="flex items-center gap-x-4 justify-end lg:col-span-5 lg:ml-4 lg:col-span-6">
           <Button onPress={()=> {resetDate()}} variant="bordered" className="border-surface-000 border-1 bg-primary text-white hover:cursor-pointer hidden md:block">Today</Button>
           <ButtonGroup>
               <Button isIconOnly onPress={() => {changeDate(-1, currView)}} variant="bordered" className="border-surface-000 border-1 bg-primary text-white hover:cursor-pointer "><FaArrowLeft /></Button>

--- a/src/components/CalendarControls/index.tsx
+++ b/src/components/CalendarControls/index.tsx
@@ -46,7 +46,7 @@ export default function CalendarControls({currDisplayDate, updateDisplayDate, cu
     }
     return (
     <>
-    <div className="gap-y-4 lg:flex lg:grid-cols-2 lg:w-full lg:justify-between">
+    <div className="sm:flex sm:flex-row md:grid lg:flex lg:grid-cols-2 w-full justify-between gap-x-4">
       <div className="flex items-center pb-1 lg:pb-0 lg:col-span-1">
         <div className="text-xl font-bold">{currView == Views.DAY ? getCurrentDate(currDisplayDate) : extractMonthAndYear(currDisplayDate)}</div>
       </div>

--- a/src/components/CalendarEventDetail/CalendarEventDetail.tsx
+++ b/src/components/CalendarEventDetail/CalendarEventDetail.tsx
@@ -30,7 +30,7 @@ function CalendarEventDetail({
     }
     if (title === undefined) {
         return (
-            <p className='text-center mt-2'>Click on an event to see more details!</p>
+            <p className='text-center mt-2 xl:w-full xl:pt-5'>Click on an event to see more details!</p>
         )
     } else {
         moment.tz.guess()


### PR DESCRIPTION
### Updated alignment for calendar page
XL
<img width="650" alt="Screenshot 2025-02-25 at 22 39 01" src="https://github.com/user-attachments/assets/d8127c24-973b-4d5a-8dc5-ffd1df4abb78" />
LG
<img width="550" alt="Screenshot 2025-02-15 at 12 48 40" src="https://github.com/user-attachments/assets/33a4298f-fbae-41a4-a592-7d793d63f871" />
MD
<img width="450" alt="Screenshot 2025-02-15 at 12 49 48" src="https://github.com/user-attachments/assets/8d2cfc3f-d284-4855-a77b-cbf5916336ae" />
SM
<img width="350" alt="Screenshot 2025-02-25 at 22 35 41" src="https://github.com/user-attachments/assets/ce6be26d-53f7-410f-ba2c-27ad6634fd1a" />
Mobile
<img width="188" alt="Screenshot 2025-02-25 at 22 37 45" src="https://github.com/user-attachments/assets/d196430a-e057-47bc-96f9-1e6174385034" />


Updated Files  
- **calendar > page.tsx**: grid column ratio for each breakpoint, **Filter dropdown**, **Events search bar**
- **CalendarControls > index.tsx**: double-row or single-row layout for different breakpoints
- **CalendarEventDetail.tsx**: centered placeholder text in XL