### PR TITLE
Remove Illinois email notice from merch-store path

### DIFF
--- a/src/app/(membership)/merch-store/page.tsx
+++ b/src/app/(membership)/merch-store/page.tsx
@@ -71,9 +71,6 @@ const MerchStore = () => {
                 <p>
                   <b>Cost:</b> ${decimalHelper(val["item_price"]["paid"])} for {(val['valid_member_lists'] && val['valid_member_lists'].length > 0) ? 'paid ACM@UIUC and eligible partner organization' : 'paid ACM@UIUC'} members, ${decimalHelper(val["item_price"]["others"])} for non-members.
                 </p>
-                <p>
-                  <b>You must use your Illinois email to receive the member discount!</b>
-                </p>
                 {
                   (val["limit_per_person"] && val["limit_per_person"] > 0) ? (
                     <i>


### PR DESCRIPTION
Only show the paid member notice when you click into the item.