### PR TITLE
Switch to lucide-preact

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@nanostores/preact": "^1.1.0",
     "astro-compress": "^2.4.0",
     "date-fns": "^4.1.0",
-    "lucide-react": "^0.577.0",
+    "lucide-preact": "^1.8.0",
     "nanostores": "^1.2.0",
     "preact": "^10.29.1",
     "react-big-calendar": "^1.19.4",

--- a/src/components/AuthActionButton.tsx
+++ b/src/components/AuthActionButton.tsx
@@ -1,6 +1,6 @@
 import type { IPublicClientApplication } from '@azure/msal-browser';
-import type { LucideIcon } from 'lucide-react';
-import { Loader2 } from 'lucide-react';
+import type { LucideIcon } from 'lucide-preact';
+import { Loader2 } from 'lucide-preact';
 import { useEffect, useRef, useState } from 'react';
 
 import { getUserAccessToken, initMsalClient } from '../authConfig.ts';

--- a/src/components/ErrorPopup.tsx
+++ b/src/components/ErrorPopup.tsx
@@ -1,4 +1,4 @@
-import { CircleAlert } from 'lucide-react';
+import { CircleAlert } from 'lucide-preact';
 import { useCallback, useState } from 'preact/hooks';
 
 import NoticePopup from './NoticePopup.tsx';

--- a/src/components/JoinModal.tsx
+++ b/src/components/JoinModal.tsx
@@ -1,5 +1,5 @@
 import { SiDiscord } from '@icons-pack/react-simple-icons';
-import { LucideArrowRight } from 'lucide-react';
+import { LucideArrowRight } from 'lucide-preact';
 import { useEffect, useState } from 'preact/hooks';
 
 interface Props {

--- a/src/components/MembershipCheckButton.tsx
+++ b/src/components/MembershipCheckButton.tsx
@@ -1,4 +1,4 @@
-import { IdCard } from 'lucide-react';
+import { IdCard } from 'lucide-preact';
 import { useState } from 'react';
 
 import { membershipApiClient } from '../api/index.js';

--- a/src/components/MembershipPurchaseButton.tsx
+++ b/src/components/MembershipPurchaseButton.tsx
@@ -1,5 +1,5 @@
 import { ResponseError } from '@acm-uiuc/core-client';
-import { ShoppingCart } from 'lucide-react';
+import { ShoppingCart } from 'lucide-preact';
 import { useState } from 'react';
 
 import { membershipApiClient } from '../api/index.js';

--- a/src/components/MembershipStatusPopup.tsx
+++ b/src/components/MembershipStatusPopup.tsx
@@ -1,4 +1,4 @@
-import { CircleCheck, CircleX, Wallet } from 'lucide-react';
+import { CircleCheck, CircleX, Wallet } from 'lucide-preact';
 import { useEffect, useRef, useState } from 'preact/hooks';
 import QRCode_ from 'react-qrcode-logo';
 import type { ComponentType } from 'preact';

--- a/src/components/NetIdSyncButton.tsx
+++ b/src/components/NetIdSyncButton.tsx
@@ -1,4 +1,4 @@
-import { CircleCheck, RefreshCcw } from 'lucide-react';
+import { CircleCheck, RefreshCcw } from 'lucide-preact';
 import { useState } from 'react';
 
 import { genericApiClient } from '../api/index.js';

--- a/src/components/NoticePopup.tsx
+++ b/src/components/NoticePopup.tsx
@@ -1,4 +1,4 @@
-import { X } from 'lucide-react';
+import { X } from 'lucide-preact';
 import type { ComponentChildren } from 'preact';
 import { useEffect, useRef, useState } from 'preact/hooks';
 

--- a/src/components/OrganizationCard.tsx
+++ b/src/components/OrganizationCard.tsx
@@ -4,7 +4,7 @@ import {
   SiInstagram,
   SiSlack,
 } from '@icons-pack/react-simple-icons';
-import { Globe, Link, Mail, RefreshCcw } from 'lucide-react';
+import { Globe, Link, Mail, RefreshCcw } from 'lucide-preact';
 import type { JSX } from 'preact/jsx-runtime';
 import { useState } from 'preact/hooks';
 

--- a/src/components/OrganizationGrid.tsx
+++ b/src/components/OrganizationGrid.tsx
@@ -9,7 +9,7 @@ import {
 } from '../stores/organization';
 import { $searchQuery } from '../stores/search';
 import OrganizationCard from './OrganizationCard';
-import { Search } from 'lucide-react';
+import { Search } from 'lucide-preact';
 
 interface ImageData {
   src: string;

--- a/src/components/SearchFilter.tsx
+++ b/src/components/SearchFilter.tsx
@@ -1,4 +1,4 @@
-import { Search } from 'lucide-react';
+import { Search } from 'lucide-preact';
 import { useEffect, useRef, useState } from 'preact/hooks';
 
 import { setSearchQuery as updateSearchQuery } from '../stores/search';

--- a/src/components/UpcomingEvents.tsx
+++ b/src/components/UpcomingEvents.tsx
@@ -1,4 +1,4 @@
-import { Calendar, Repeat } from 'lucide-react';
+import { Calendar, Repeat } from 'lucide-preact';
 import { useEffect, useState } from 'preact/hooks';
 
 import { eventsApiClient } from '../api';

--- a/src/components/calendar/CalendarControls.tsx
+++ b/src/components/calendar/CalendarControls.tsx
@@ -1,6 +1,6 @@
 import { add, format, getDay, parse, startOfWeek } from 'date-fns';
 import { enUS } from 'date-fns/locale/en-US';
-import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { ChevronLeft, ChevronRight } from 'lucide-preact';
 import type { ComponentChildren } from 'preact';
 import type { View } from 'react-big-calendar';
 import { dateFnsLocalizer, Views } from 'react-big-calendar';

--- a/src/components/calendar/CalendarEventDetail.tsx
+++ b/src/components/calendar/CalendarEventDetail.tsx
@@ -1,4 +1,4 @@
-import { Calendar, LogIn, MapPin, User } from 'lucide-react';
+import { Calendar, LogIn, MapPin, User } from 'lucide-preact';
 
 import type { Event } from '../../types/events';
 

--- a/src/components/calendar/Dropdown.tsx
+++ b/src/components/calendar/Dropdown.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown } from 'lucide-react';
+import { ChevronDown } from 'lucide-preact';
 import { useEffect, useRef, useState } from 'preact/hooks';
 
 interface DropdownOption {

--- a/src/components/store/StoreItem.tsx
+++ b/src/components/store/StoreItem.tsx
@@ -3,7 +3,7 @@ import {
   ResponseError,
 } from '@acm-uiuc/core-client';
 import { useEffect, useState, useMemo, useCallback, useRef } from 'react';
-import { ShoppingCart } from 'lucide-react';
+import { ShoppingCart } from 'lucide-preact';
 import {
   storeApiClient,
   membershipApiClient,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4928,10 +4928,10 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
-lucide-react@^0.577.0:
-  version "0.577.0"
-  resolved "https://registry.yarnpkg.com/lucide-react/-/lucide-react-0.577.0.tgz#8ae89edd8415f99c6319a38b40d9c513f6fa5062"
-  integrity sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A==
+lucide-preact@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/lucide-preact/-/lucide-preact-1.8.0.tgz#92d4b19a2f49cfd2d8d3dbbf06c13a5f2643ef23"
+  integrity sha512-va4a8kofUvE324fKPgBIewfpm9IiGm1TwMN8NoveK2wwywuZIQxsXX9IJVB0+rM1I79XBMnfWNuLjIF2LwAXiQ==
 
 luxon@^3.2.1:
   version "3.7.2"


### PR DESCRIPTION
Latest version of lucide-react breaks, use the preact version instead

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal library dependencies to maintain compatibility and stability across the application. These technical changes have no impact on end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->