### PR TITLE
Fixed Linking For Paid Event Registration on Calendar

### DIFF
--- a/src/components/calendar/CalendarEventDetail.tsx
+++ b/src/components/calendar/CalendarEventDetail.tsx
@@ -37,7 +37,7 @@ export default function CalendarEventDetail({
         : '';
 
   const paidEventHref = event.paidEventId
-    ? `/store/item?id=${event.paidEventId}`
+    ? `/store/?id=${event.paidEventId}`
     : undefined;
 
   return (


### PR DESCRIPTION
fix: added proper linking for registering for paid events on calendar

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the registration link path for paid events, allowing users to successfully navigate to the registration page when attempting to register for ticketed events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->