### PR TITLE
Handle no upcoming events

### DIFF
--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -19,8 +19,15 @@ test.describe('Homepage', () => {
   });
 
   test('Join ACM button opens the Join modal', async ({ page }) => {
-    await page.locator('#hero-join-btn').click();
-    await expect(page.getByText('Join ACM @ UIUC')).toBeVisible();
+    // The hero button dispatches a custom event that the navbar listens for
+    // after it hydrates. Retry the click until the navbar's listener is
+    // registered and the modal actually opens.
+    await expect(async () => {
+      await page.locator('#hero-join-btn').click();
+      await expect(page.getByText('Join ACM @ UIUC')).toBeVisible({
+        timeout: 1000,
+      });
+    }).toPass({ timeout: 10_000 });
   });
 
   test('Sponsors section has all 5 sponsors', async ({ page }) => {

--- a/e2e/orglist.spec.ts
+++ b/e2e/orglist.spec.ts
@@ -134,7 +134,17 @@ test.describe('Org list pre-compilation', () => {
     const committeesTab = page.getByRole('button', {
       name: /Committees/i,
     });
-    await committeesTab.click();
+    await expect(committeesTab).toBeVisible();
+
+    // The tab is rendered in SSR HTML before its onClick is attached, so the
+    // first click may fire before OrgTypeTabBar hydrates. Retry until the
+    // active tab actually switches.
+    await expect(async () => {
+      await committeesTab.click();
+      await expect(committeesTab).toHaveAttribute('aria-selected', 'true', {
+        timeout: 1000,
+      });
+    }).toPass({ timeout: 10_000 });
 
     const cards = page.locator('[data-testid="org-grid"] h3:visible');
     await expect(cards.first()).toBeVisible();

--- a/e2e/upcomingEvents.spec.ts
+++ b/e2e/upcomingEvents.spec.ts
@@ -1,0 +1,79 @@
+import { test, expect } from '@playwright/test';
+
+const futureDateTime = (daysFromNow: number) => {
+  const d = new Date();
+  d.setDate(d.getDate() + daysFromNow);
+  d.setSeconds(0, 0);
+  return d.toISOString().replace(/\.\d{3}Z$/, '');
+};
+
+test.describe('UpcomingEvents empty state', () => {
+  test('shows compact empty banner when no featured events', async ({
+    page,
+  }) => {
+    await page.route('**/api/v1/events**', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([]),
+      })
+    );
+
+    await page.goto('/');
+
+    const banner = page.getByText(
+      /No featured events right now — check back soon\./i
+    );
+    await expect(banner).toBeVisible();
+
+    const seeAll = page.getByRole('link', { name: /See all events/i });
+    await expect(seeAll).toBeVisible();
+    await expect(seeAll).toHaveAttribute('href', '/calendar');
+  });
+
+  test('See all events link navigates to /calendar', async ({ page }) => {
+    await page.route('**/api/v1/events**', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([]),
+      })
+    );
+
+    await page.goto('/');
+    await page.getByRole('link', { name: /See all events/i }).click();
+    await expect(page).toHaveURL(/\/calendar$/);
+  });
+
+  test('renders event cards (not the empty banner) when events are featured', async ({
+    page,
+  }) => {
+    const mockEvent = {
+      id: 'evt-e2e-1',
+      title: 'E2E Featured Event',
+      description: 'A featured event for e2e testing.',
+      start: futureDateTime(3),
+      end: futureDateTime(3),
+      featured: true,
+      host: 'ACM',
+      location: 'Siebel CS',
+    };
+
+    await page.route('**/api/v1/events**', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([mockEvent]),
+      })
+    );
+
+    await page.goto('/');
+
+    await expect(
+      page.getByRole('heading', { name: 'E2E Featured Event' })
+    ).toBeVisible();
+    await expect(page.getByText(/No featured events right now/i)).toHaveCount(
+      0
+    );
+  });
+});

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -164,7 +164,7 @@ const { disableBounce } = Astro.props;
       </div>
     </div>
 
-    <UpcomingEvents client:load />
+    <UpcomingEvents client:only="preact" />
   </section>
 </div>
 

--- a/src/components/UpcomingEvents.tsx
+++ b/src/components/UpcomingEvents.tsx
@@ -201,9 +201,12 @@ const readCache = (): Event[] | null => {
   try {
     const raw = window.localStorage.getItem(CACHE_KEY);
     if (!raw) return null;
-    const parsed = JSON.parse(raw) as { ts: number; events: Event[] };
-    if (Date.now() - parsed.ts > CACHE_TTL_MS) return null;
-    return parsed.events;
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== 'object') return null;
+    const { ts, events } = parsed as { ts?: unknown; events?: unknown };
+    if (typeof ts !== 'number' || Date.now() - ts > CACHE_TTL_MS) return null;
+    if (!Array.isArray(events)) return null;
+    return events as Event[];
   } catch {
     return null;
   }

--- a/src/components/UpcomingEvents.tsx
+++ b/src/components/UpcomingEvents.tsx
@@ -1,4 +1,4 @@
-import { Calendar, Repeat } from 'lucide-preact';
+import { ArrowRight, Calendar, CalendarClock, Repeat } from 'lucide-preact';
 import { useEffect, useState } from 'preact/hooks';
 
 import { eventsApiClient } from '../api';
@@ -183,9 +183,51 @@ const SkeletonCard = () => (
   <div className="animate-pulse rounded-xl border border-gray-200 bg-gray-200 p-5 h-full min-h-[200px]" />
 );
 
+const CACHE_KEY = 'acm:upcomingEvents:v1';
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+
+const processEvents = (raw: Event[]): Event[] =>
+  transformEventsApiDates(raw.filter((x) => x.featured))
+    .map(getNextOccurrence)
+    .sort((a, b) => {
+      const aStart = Temporal.PlainDateTime.from(a.start);
+      const bStart = Temporal.PlainDateTime.from(b.start);
+      return Temporal.PlainDateTime.compare(aStart, bStart);
+    })
+    .slice(0, 3);
+
+const readCache = (): Event[] | null => {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.localStorage.getItem(CACHE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as { ts: number; events: Event[] };
+    if (Date.now() - parsed.ts > CACHE_TTL_MS) return null;
+    return parsed.events;
+  } catch {
+    return null;
+  }
+};
+
+const writeCache = (events: Event[]) => {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(
+      CACHE_KEY,
+      JSON.stringify({ ts: Date.now(), events })
+    );
+  } catch {
+    // ignore quota / disabled storage
+  }
+};
+
 const UpcomingEvents = () => {
-  const [featuredEvents, setFeaturedEvents] = useState<Event[]>([]);
-  const [loading, setLoading] = useState(true);
+  const cached = readCache();
+  const [featuredEvents, setFeaturedEvents] = useState<Event[]>(() =>
+    cached ? processEvents(cached) : []
+  );
+  const [loading, setLoading] = useState(cached === null);
+
   useEffect(() => {
     const fetchEvents = async () => {
       try {
@@ -193,15 +235,8 @@ const UpcomingEvents = () => {
           upcomingOnly: true,
           featuredOnly: true,
         });
-        const response = transformEventsApiDates(raw.filter((x) => x.featured))
-          .map(getNextOccurrence)
-          .sort((a, b) => {
-            const aStart = Temporal.PlainDateTime.from(a.start);
-            const bStart = Temporal.PlainDateTime.from(b.start);
-            return Temporal.PlainDateTime.compare(aStart, bStart);
-          })
-          .slice(0, 3);
-        setFeaturedEvents(response);
+        setFeaturedEvents(processEvents(raw));
+        writeCache(raw);
       } catch (error) {
         console.error('Error fetching events:', error);
       } finally {
@@ -216,6 +251,22 @@ const UpcomingEvents = () => {
     return (
       <div className="grid grid-cols-1 gap-6">
         <SkeletonCard />
+      </div>
+    );
+  }
+
+  if (featuredEvents.length === 0) {
+    return (
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-2 rounded-lg border border-dashed border-white/25 bg-white/5 px-4 py-3 text-sm text-white/80 backdrop-blur-sm">
+        <CalendarClock className="text-tangerine-300 shrink-0" size={18} />
+        <span>No featured events right now — check back soon.</span>
+        <a
+          href="/calendar"
+          className="ml-auto inline-flex items-center gap-1 font-semibold text-white underline-offset-2 hover:underline"
+        >
+          See all events
+          <ArrowRight size={16} className="shrink-0" />
+        </a>
       </div>
     );
   }


### PR DESCRIPTION
Add a better fallback for when there are no upcoming events instead of just showing an awkward section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added empty state display for upcoming events with link to view all events.

* **Bug Fixes**
  * Improved reliability of button interactions and component visibility during page load.
  * Enhanced event data loading performance through caching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->